### PR TITLE
Remove test_utils warning

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ obj_test_deflate = ${patsubst %.c, %.o, $(SRC_DEFLATE)}
 obj_test_inflate = ${patsubst %.c, %.o, $(SRC_INFLATE)}
 obj_test_stress  = ${patsubst %.c, %.o, $(SRC_STRESS)}
 
-TEST_OBJS = $(obj_test_deflate) $(obj_test_inflate) $(obj_test_stress)
+TEST_OBJS = $(sort $(obj_test_deflate) $(obj_test_inflate) $(obj_test_stress))
 EXE = test_inflate test_deflate test_stress
 
 all: $(EXE)


### PR DESCRIPTION
This patch sorts the list of test objects requirements to remove duplicates and
remove the test_utils.o warnings.